### PR TITLE
fix bug for unique constraint on multiple columns

### DIFF
--- a/src/Parser/SchemaParser.php
+++ b/src/Parser/SchemaParser.php
@@ -77,6 +77,7 @@ class SchemaParser
             }
 
             if (in_array($column['type'], [
+                'unique',
                 'tinyIncrements',
                 'smallIncrements',
                 'mediumIncrements',


### PR DESCRIPTION
when using table with unique constraint on multiple columns
## Table

```
CREATE TABLE `events_subscriptions` (
    `id` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
    `post_id` INT(10) UNSIGNED NOT NULL,
    `user_id` INT(10) UNSIGNED NOT NULL,
    `invited_by_user_id` INT(10) UNSIGNED NULL DEFAULT NULL,
    `accepte` TINYINT(1) NOT NULL DEFAULT '0',
    `refuse` TINYINT(1) NOT NULL DEFAULT '0',
    `created_at` TIMESTAMP NOT NULL DEFAULT '0000-00-00 00:00:00',
    `updated_at` TIMESTAMP NOT NULL DEFAULT '0000-00-00 00:00:00',
    PRIMARY KEY (`id`),
__UNIQUE INDEX `events_subscriptions_post_id_user_id_unique` (`post_id`, `user_id`),__
    INDEX `events_subscriptions_user_id_foreign` (`user_id`),
    INDEX `events_subscriptions_invited_by_user_id_foreign` (`invited_by_user_id`),
    INDEX `events_subscriptions_accepte_index` (`accepte`),
    INDEX `events_subscriptions_refuse_index` (`refuse`),
    CONSTRAINT `events_subscriptions_invited_by_user_id_foreign` FOREIGN KEY (`invited_by_user_id`) REFERENCES `users` (`id`) ON DELETE SET NULL,
    CONSTRAINT `events_subscriptions_post_id_foreign` FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`) ON DELETE CASCADE,
    CONSTRAINT `events_subscriptions_user_id_foreign` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE
    )
    COLLATE='utf8_unicode_ci'
    ENGINE=InnoDB;
```
## error

```
php artisan generator:make:model myTable
Generating models for: myTable
[ErrorException]
Array to string conversion
```
## Tips

```
FieldParser::generate() return array_merge($fields, $indexes);
// when calling
SchemaParser::getFillableFieldsFromSchema()
// and do foreach on FieldParser::generate() result,
// you considered your $indexes as a new field.
// and this makes ErrorException.
// your $indexes that you get with FieldParser::getMultiFieldIndexes() are not really fields.
```
